### PR TITLE
updating version 04 Comments from Tero

### DIFF
--- a/draft-ietf-ipsecme-rfc4307bis
+++ b/draft-ietf-ipsecme-rfc4307bis
@@ -58,7 +58,7 @@
         <email>pwouters@redhat.com</email>
       </address>
     </author>
-    <author fullname="Daniel Migault" initials="D." surname="Migault">
+    <author fullname="Daniel Migault" initials="D." surname="Migault" role="editor">
       <organization> Ericsson </organization>
       <address>
         <postal>
@@ -100,7 +100,7 @@
         a set of "mandatory-to-implement" IKEv2 encryption algorithms is defined. </t>
         
      <section title="Updating Algorithm Implementation Requirements and Usage Guidance">   
-      <t> The field of cryptography evolves continiously. New stronger algorithms appear and existing algorithms are found
+      <t> The field of cryptography evolves continuously. New stronger algorithms appear and existing algorithms are found
         to be less secure then originally thought. Therefore, algorithm implementation requirements and usage guidance need
         to be updated from time to time to reflect the new reality. The choices for algorithms must be conservative
         to minimize the risk of algorithm compromised. Algorithms need to be suitable for a wide variety of CPU architectures
@@ -115,7 +115,7 @@
       <t> Ideally, the mandatory-to-implement algorithm of tomorrow should already be available in most implementations 
         of IKE by the time it is made mandatory.  To facilitate this, this document attempts to identify those algorithms 
         for future mandatory-to-implement. There is no guarantee that the algorithms in use today may become mandatory
-        in the future. Published algorithms are continiously subjected to cryptographic attack and may become too weak or
+        in the future. Published algorithms are continuously subjected to cryptographic attack and may become too weak or
         could become completely broken before this document is updated.</t>
 
       <t> This document only provides recommendations for the mandatory-to-implement algorithms or algorithms
@@ -135,8 +135,8 @@
         SHOULD instead of a MUST.</t>
       
       <t>The current trend toward Internet of Things and its adoption of IKEv2 requires this specific use case to be taken
-       into account as well. IoT devices are resource constrainted devices and their choice of algorithms are motivated by
-       minimizing the fooprint of the code, the computation effort and the size of the messages to send. This document
+       into account as well. IoT devices are resource constrained devices and their choice of algorithms are motivated by
+       minimizing the footprint of the code, the computation effort and the size of the messages to send. This document
        indicates IoT when a specified algorithm is specifically listed for IoT devices.</t>  
      </section>
 
@@ -200,7 +200,7 @@
         RFC4307.</t>
         <t> ENCR_CHACHA20_POLY1305 was not ready to be considered at the time of RFC4307.
          It has been recommended by the CRFG and others as an alternative to AES and AES-GCM. It is also being
-         standarized for IPsec for the same reasons. At the time of writing, there were not enough IKEv2 implementations
+         standardized for IPsec for the same reasons. At the time of writing, there were not enough IKEv2 implementations
          of ENCR_CHACHA20_POLY1305 to be able to introduce it at the SHOULD+ level.</t>
         <t> AES-GCM with a 16 octet ICV was not considered as in RFC4307. At the time RFC4307
         was written, AES-GCM was not defined in an IETF document. AES-GCM was defined for ESP in 
@@ -209,7 +209,7 @@
         This resulted in AES-GCM widely implemented for ESP. As the load of IKEv2 is expected to remain 
         relatively small, many IKEv2 implementations do not include AES-GCM. In addition to its former MAY, this document
         does not promote AES-GCM to a greater status than SHOULD so to preserve interoperability between IKEv2
-        implementations. [PAUL: I dont follow the reasoning, as we could have AES and AES-GCM at MUST level]
+        implementations. 
         This document considers AES-GCM as mandatory to implement to promote the slightly more secure AEAD method
         over the traditional encrypt+auth method. Its status is expected to be raised once widely deployed.</t>
         <t> ENCR_AES_CCM_8 was not considered in RFC4307. This document considers it 
@@ -220,8 +220,7 @@
         MAY be implemented for key length 256.</t>
         <t> ENCR_3DES has been downgraded from RFC4307 MUST-. All IKEv2 implementation already implement
         ENCR_AES_CBC, so there is no need to keep ENCR_3DES. In addition, ENCR_CHACHA20_POLY1305 provides a more 
-        modern alternative to AES. [PAUL: removed 'efficient' as we said above encryption efficiency at the IKE
-        level hardly matters]</t>
+        modern alternative to AES.</t>
         <t> ENCR_DES can be brute-forced using of-the-shelves hardware. It provides no meaningful security
           whatsoever and therefor MUST NOT be implemented.</t>
       </section>
@@ -229,7 +228,7 @@
   
       <section anchor="algs_prf" title="Type 2 - IKEv2 Pseudo-random Function Transforms">
         <t> Transform Type 2 Algorithms are pseudo-random functions used to generate random values when needed.</t>
-        <t>In general, if you can trust an algorithm as INTEG algorithm, you can and should also use it as the PRF.
+        <t>In general, if you can trust an algorithm as integrity algorithm, you can and should also use it as the PRF.
           When using an AEAD cipher, the choice is PRF is open, and picking one of the SHA2 variants is recommended.</t>
         <texttable anchor="tbl_alg2" suppress-title="true">
           <ttcol align="left">Name</ttcol>
@@ -239,8 +238,10 @@
           <c>PRF_HMAC_SHA2_512</c><c>SHOULD+</c><c></c>
           <c>PRF_HMAC_SHA1</c><c>MUST-</c><c>[1]</c>
           <c>PRF_AES128_CBC</c><c>SHOULD</c><c>[IoT]</c>
+          <c>PRF_HMAC_MD5</c><c>MUST NOT</c><c></c>
           <postamble> 
-          
+          [1] - This requirement level is for 128-bit keys. 256-bit keys are at MAY. 192-bit keys can 
+            safely be ignored.
           [IoT] - This requirement is for interoperability with IoT 
             </postamble>
         </texttable>
@@ -250,11 +251,13 @@
         <t> PRF_HMAC_SHA2_512 SHOULD be implemented as as a future replacement of SHA2_256 or when stronger 
         security is required. PRF_HMAC_SHA2_512 is preferred over PRF_HMAC_SHA2_384, as the overhead of 
         PRF_HMAC_SHA2_512 is negligible.</t>
-        <t> PRF_HMAC_SHA1_96 has been downgraded from MUST in RFC4307. 
+        <t> PRF_HMAC_SHA1 has been downgraded from MUST in RFC4307 to MUST-. 
         There is an industry-wide trend to deprecate its usage.</t>
         <t> PRF_AES128_CBC is only recommended in the scope of IoT, as Internet of Things deployments tend to 
         prefer AES based pseudo-random functions in  order to avoid implementing SHA2. For the wide VPN 
         deployment, as it has not been widely adopted, it has been downgraded from SHOULD in RFC4307 to MAY.</t>
+        <t>PRF_HMAC_MD5 has been downgraded from MAY in RFC4307 to MUST NOT. There is an industry-wide trend to 
+        deprecate its usage. MD5 is known to be subject to collision which can lead to transcript attacks.</t>  
       </section>
 
       <section anchor="algs_integ" title="Type 3 - IKEv2 Integrity Algorithm Transforms">
@@ -267,7 +270,7 @@
           <ttcol align="left">Comment</ttcol>
           <c>AUTH_HMAC_SHA2_256_128</c><c>MUST</c><c></c>
           <c>AUTH_HMAC_SHA2_512_256</c><c>SHOULD</c><c></c>
-          <c>AUTH_HMAC_SHA1_96</c><c>SHOULD</c><c></c>
+          <c>AUTH_HMAC_SHA1_96</c><c>MUST-</c><c></c>
           <c>AUTH_AES_XCBC_96</c><c>SHOULD</c><c>[IoT]</c>
           <postamble> 
           [IoT] - This requirement is for interoperability with IoT 
@@ -278,7 +281,7 @@
         <t> AUTH_HMAC_SHA2_512_256 SHOULD be implemented as as a future replacement of AUTH_HMAC_SHA2_256_128
          or when stronger security is required. This value has been preferred to AUTH_HMAC_SHA2_384, as the overhead of 
         AUTH_HMAC_SHA2_512 is negligible.</t>
-        <t> AUTH_HMAC_SHA1_96 has been downgraded from MUST in RFC4307. 
+        <t> AUTH_HMAC_SHA1_96 has been downgraded from MUST in RFC4307 to MUST-. 
         There is an industry-wide trend to deprecate its usage.</t>
         <t> AUTH_AES-XCBC is only recommended in the scope of IoT, as Internet of Things deployments tend 
         to prefer AES based pseudo-random functions in  order to avoid implementing SHA2. For the wide VPN
@@ -298,15 +301,15 @@
           <c>5</c><c>1536-bit MODP Group</c><c>SHOULD NOT</c>
           <c>2</c><c>1024-bit MODP Group</c><c>SHOULD NOT</c>
           <c>1</c><c>768-bit MODP Group</c><c>MUST NOT</c>
-          <c>22</c><c>1024-bit MODP Group with 160-bit Prime Order Subgroup</c><c>MUST NOT</c>
-          <c>23</c><c>1024-bit MODP Group with 224-bit Prime Order Subgroup</c><c>MUST NOT</c>
-          <c>24</c><c>1024-bit MODP Group with 256-bit Prime Order Subgroup</c><c>MUST NOT</c>
+          <c>22</c><c>1024-bit MODP Group with 160-bit Prime Order Subgroup</c><c>SHOULD NOT</c>
+          <c>23</c><c>1024-bit MODP Group with 224-bit Prime Order Subgroup</c><c>SHOULD NOT</c>
+          <c>24</c><c>1024-bit MODP Group with 256-bit Prime Order Subgroup</c><c>SHOULD NOT</c>
         </texttable>
         <t> Group 14 or 2048-bit MODP Group is raised from SHOULD+ in RFC4307 as a replacement for 
         1024-bit MODP Group. Group 14 is widely implemented and considered secure</t>
         <t> Group 19 or 256-bit random ECP group was not specified in RFC4307. 
         Group 19 is widely implemented and considered secure</t>
-        <t> Group 5 or 1536-bit MODP Group is downgrade from MUST- to SHOULD NOT. It was specified earlier,
+        <t> Group 5 or 1536-bit MODP Group is downgrade from MAY to SHOULD NOT. It was specified earlier,
          but now considered to be vulnerable to be broken within the next few years by a nation state level attack,
          so its security margin is considered too narrow.</t>
         <t> Group 2 or 1024-bit MODP Group is downgrade from MUST- to SHOULD NOT. 
@@ -320,7 +323,8 @@
          encourage its implementation and deployment. If it gets widely implemented then it most likely will be
          upgraded to SHOULD or even MUST in the future.</t> 
         <t>Group 22-24 or 1024-bit MODP Group with 160-bit and 2048-bit MODP Group with 224-256-bit Prime Order 
-        Subgroup are exposed to synchronization or transcription attacks.</t>
+        Subgroup are envisioned to become small subgroups in a near future. It is expected in the
+        near future to be further downgraded to MUST NOT.</t>
       </section>
     </section>
     <section title="IKEv2 Authentication">
@@ -336,8 +340,8 @@
            <ttcol align="left">Comment</ttcol>
           <c>1</c><c>RSA Digital Signature</c><c>MUST</c><c>With keys length 2048</c>
           <c>1</c><c>RSA Digital Signature</c><c>SHOULD</c><c>With keys length 3072/4096</c>
-          <c>1</c><c>RSA Digital Signature</c><c>MUST NOT</c><c>With keys length lower than 2048</c>
-          <c>3</c><c>DSS Digital Signature</c><c>MAY</c><c></c>
+          <c>1</c><c>RSA Digital Signature</c><c>SHOULD NOT</c><c>With keys length lower than 2048</c>
+          <c>3</c><c>DSS Digital Signature</c><c>SHOULD NOT</c><c></c>
           <c>9</c><c>ECDSA with SHA-256 on the P-256 curve</c><c>SHOULD</c><c></c>
           <c>10</c><c>ECDSA with SHA-384 on the P-384 curve</c><c>SHOULD</c><c></c>
           <c>11</c><c>ECDSA with SHA-512 on the P-521 curve</c><c>SHOULD</c><c></c>
@@ -345,14 +349,19 @@
         </texttable>
         
         <t>RSA Digital Signature is mostly kept for interoperability. It is expected to be downgraded 
-        in the future as signatures are based on RSASSA-PKCS1-v1.5, not any more recommemded. 
-        Instead, more robust use of RSA is expected to be performed via the Digital Signature method.</t>
+        in the future as signatures are based on RSASSA-PKCS1-v1.5, not any more recommended. 
+        Instead, more robust use of RSA is expected to be performed via the Digital Signature method. 
+        RSA Digital Signature are not recommended to use keys lower that 2048. These key lengths have
+        not been further downgraded to remain coherent with the 1024-bit MODP Group whose status has been
+        set to SHOULD NOT. Unlike 1024-bit MODP, attacks on authentication requires an online attacks and
+        attacks performed after the authentication phase have very little value. On the other hand,
+        attacks performed on the Diffie Hellman exchange after the initial exchange can lead to a 
+        complete decryption of the communication.</t>
         <t>ECDSA family are also expected to be downgraded as it does not provide hash function agility.
         Instead ECDSA is expected to be performed using the generic Digital Signature method.</t>
-        <t>DSS Digital Signature is bound to SHA-1 and thus is expected to be downgraded to MUST NOT in the future.</t> 
+        <t>DSS Digital Signature is bound to SHA-1 and has the same level of security as 1024-bit RSA. 
+        It is expected to be downgraded to MUST NOT in the future.</t> 
         <t>Digital Signature is expected to be promoted as it provides hash function, signature format and algorithm agility.</t> 
-      
-      <t>[MGLT: Do we have any recommendation for the authentication based on PSK?]</t> 
       </section>
       
       <section title="Digital Signature Recommendation">
@@ -366,7 +375,7 @@
            <ttcol align="left">Comment</ttcol>
           <c>OID</c><c>RSA</c><c>MUST</c><c>With keys length 2048</c>
           <c>OID</c><c>RSA</c><c>SHOULD</c><c>With keys length 3072/4096</c>
-          <c>OID</c><c>RSA</c><c>MUST NOT</c><c>With keys length lower than 2048</c>
+          <c>OID</c><c>RSA</c><c>SHOULD NOT</c><c>With keys length lower than 2048</c>
           <c>OID</c><c>ECDSA</c><c>SHOULD</c><c></c>
         </texttable>      
  


### PR DESCRIPTION
z) I  

a) DH

<c>22</c><c>1024-bit MODP Group with 160-bit Prime Order Subgroup</c><c>SHOULD NOT</c>
<c>23</c><c>1024-bit MODP Group with 224-bit Prime Order Subgroup</c><c>SHOULD NOT</c>
<c>24</c><c>1024-bit MODP Group with 256-bit Prime Order Subgroup</c><c>SHOULD NOT</c>

<t> Group 5 or 1536-bit MODP Group is downgrade from MAY to SHOULD NOT. It was specified earlier,
but now considered to be vulnerable to be broken within the next few years by a nation state level attack,
so its security margin is considered too narrow.</t>

<t>Group 22-24 or 1024-bit MODP Group with 160-bit and 2048-bit MODP Group with 224-256-bit Prime Order 
Subgroup are envisioned to become small subgroups in a near future. It is expected in the
near future to be further downgraded to MUST NOT.</t>

COMMENT: Should we add any reference to the checks that needs to be performed.

COMMENT: Should we add in the DH intro that DH needs to implement strong security as to preserve perfect forward secrecy.

b) auth

<c>AUTH_HMAC_SHA1_96</c><c>MUST-</c><c></c>
<t> AUTH_HMAC_SHA1_96 has been downgraded from MUST in RFC4307 to MUST-. 
        There is an industry-wide trend to deprecate its usage.</t>

COMMENT: This leaves a MUST- notation. The other alternative could be to have SHOULD with the additional text specifying the next step is expected to be SHOULD NOT. 

c) prf

<c>PRF_HMAC_MD5</c><c>MUST NOT</c><c></c>
COMMENT: should we have a reference to https://www.mitls.org/downloads/transcript-collisions.pdf 

<t>PRF_HMAC_MD5 has been downgraded from MAY in RFC4307 to MUST NOT. There is an industry-wide trend to 
        deprecate its usage. MD5 is known to be subject to collision which can lead to transcript attacks.  

<c>3</c><c>DSS Digital Signature</c><c>SHOULD NOT</c><c></c>
<t>DSS Digital Signature is bound to SHA-1 and has the same level of security as 1024-bit RSA. It is expected to be downgraded to MUST NOT in the future.</t>                 

d) rsa

<t>RSA Digital Signature is mostly kept for interoperability. It is expected to be downgraded 
in the future as signatures are based on RSASSA-PKCS1-v1.5, not any more recommended. 
Instead, more robust use of RSA is expected to be performed via the Digital Signature method. 
RSA Digital Signature are not recommended to use keys lower that 2048. These key lengths have
not been further downgraded to remain coherent with the 1024-bit MODP Group whose status has been
set to SHOULD NOT. Unlike 1024-bit MODP, attacks on authentication requires an online attack and
attacks performed after the authentication phase have very little value. On the other hand,
attacks performed on the Diffie Hellman exchange after the initial exchange can lead to a 
complete decryption of the communication.</t>

e) psk

Do we have any recommendation for the authentication based on PSK?

f) oid

What are the OID values for RSA / ECDSA?

<c>OID</c><c>RSA</c><c>MUST</c><c>With keys length 2048</c>
<c>OID</c><c>RSA</c><c>SHOULD</c><c>With keys length 3072/4096</c>
<c>OID</c><c>RSA</c><c>SHOULD NOT</c><c>With keys length lower than 2048</c>
<c>OID</c><c>ECDSA</c><c>SHOULD</c><c></c> 

COMMENT: Shouldn't we rather remove MD5 from the Digital Signature Recommendation section ?

COMMENT: Currently SHA1 status is set to MUST. Shouldn't we set it to MUST- ?
