### PR TITLE
Document structure & clarifications

### DIFF
--- a/draft-ietf-ipsecme-ddos-protection.xml
+++ b/draft-ietf-ipsecme-ddos-protection.xml
@@ -283,7 +283,24 @@
             to pass ICV check), then the Responder SHOULD still keep the computed
             SK_* keys, so that if it happened to be an attack, then the malicious
             Initiator cannot get advantage of repeating the attack multiple times on a single IKE SA.
-            The responder can also use puzzles in the IKE_AUTH exchange as decribed in <xref target="ikeauth"/>.</t>
+            The responder can also use puzzles in the IKE_AUTH exchange as decribed in <xref target="ikeauth"/>.
+            </t>
+        </section>
+
+        <section anchor="hashandurl" title="Preventing Attacks using &quot;Hash and URL&quot; Certificate Encoding">
+            <t> In IKEv2 each side may use "Hash and URL" Certificate Encoding to instruct the peer 
+            to retrieve certificates from the specified location (see Section 3.6 of <xref target="RFC7296"/> for details).
+            Malicious initiators can use this feature to mount a DoS attack on responder by providing an URL pointing to a large file
+            possibly containing garbage. While downloading the file the responder consumes CPU, memory and network bandwidth.
+            </t>
+            <t> To prevent this kind of attacks the responder should not blindly download the whole file. 
+            Instead it SHOULD first read the initial few bytes, decode the length of the ASN.1 structure 
+            from these bytes, and then download no more than the decoded number of bytes. Note, that it is always
+            possible to determine the length of ASN.1 structures used in IKEv2 by analyzing the first few bytes,
+            if they are DER-encoded. Implementations SHOULD also apply a configurable hard limit to the number 
+            of pulled bytes and SHOULD provide an ability for an administrator to either completely disable this 
+            feature or to limit its use to a configurable list of trusted URLs.
+            </t>
         </section>
     </section>
 
@@ -919,6 +936,9 @@ HDR, PS, SK {IDi, [CERT,] [CERTREQ,]
         Responders that allow unauthenticated Initiators to connect must be prepared deal
         with various kinds of DoS attacks even after IKE SA is created. See <xref target="dosprotikesa"/> for details.
         </t>
+        <t> To prevent amplification attacks implementations must strictly follow the retransmission
+        rules described in Section 2.1 of <xref target="RFC7296"/>.
+        </t>
     </section>
 
     <section anchor="iana" title="IANA Considerations">  
@@ -942,7 +962,8 @@ HDR, PS, SK {IDi, [CERT,] [CERTREQ,]
         of the protocol. In particular, Tero Kivinen suggested the kind of puzzle where the task is to find
         a solution with requested number of zero trailing bits. Yaron Sheffer and Scott Fluhrer suggested
         a way to make puzzle difficulty less erratic by solving several weaker puzles. The authors also thank
-        David Waltermire for his carefull review of the draft and all others who commented the document.
+        David Waltermire for his carefull review of the document, Graham Bartlett for pointing out to the possibility
+        of "Hash & URL" related attack, and all others who commented the document.
         </t>
     </section>
 

--- a/draft-ietf-ipsecme-ddos-protection.xml
+++ b/draft-ietf-ipsecme-ddos-protection.xml
@@ -19,7 +19,7 @@
 <?rfc sortrefs="no" ?>
 <?rfc rfcedstyle="yes"?>
 
-<rfc ipr="trust200902" docName="draft-ietf-ipsecme-ddos-protection-04" category="std">
+<rfc ipr="trust200902" docName="draft-ietf-ipsecme-ddos-protection-xx" category="std">
 
   <front>
     <title abbrev="DDoS Protection for IKEv2">Protecting Internet Key Exchange Protocol version 2 (IKEv2) Implementations from Distributed Denial of Service Attacks</title>
@@ -67,13 +67,20 @@
         bounded (regardless of how high it is) and because some resources are required
         for distinguishing a legitimate session from an attack.
         </t>
-        <t>The Internet Key Exchange protocol (IKE) described in <xref target="RFC7296"/> includes defense against 
+        <t>The Internet Key Exchange protocol version 2 (IKEv2) described in <xref target="RFC7296"/> includes defense against 
         DoS attacks. In particular, there is a cookie mechanism that allows the IKE Responder
         to effectively defend itself against DoS attacks from spoofed IP-addresses. However, bot-nets 
         have become widespread, allowing attackers to perform Distributed Denial of Service (DDoS) attacks,
         which are more difficult to defend against. This document presents recommendations to help the Responder 
         thwart (D)DoS attacks. It also introduces a new mechanism -- "puzzles" -- that can help accomplish this task.
         </t>
+    </section>
+    <section anchor="mustshouldmay" title="Conventions Used in This Document">
+      <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
+        "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described
+        in <xref target="RFC2119"/>.</t>
+    </section>
+    <section anchor="analysis" title="The Vulnerability">
       <t> The IKE_SA_INIT Exchange described in Section 1.2 of <xref target="RFC7296"/> involves the Initiator sending a single message. 
         The Responder replies with a single message and also allocates memory for a structure called a half-open IKE Security 
         Association (SA). This half-open SA is later authenticated in the IKE_AUTH Exchange. If that IKE_AUTH request never comes, 
@@ -85,26 +92,6 @@
       <t> An obvious defense, which is described in <xref target="ratelimit"/>, is limiting the number of half-open SAs opened by a 
         single peer. However, since all that is required is a single packet, an attacker can use multiple spoofed source IP 
         addresses.</t>
-      <section anchor="statelesscookie" title="The Stateless Cookie">  
-        <t> Section 2.6 of <xref target="RFC7296"/> offers a mechanism to mitigate this DoS attack: the stateless cookie. When the server 
-          is under load, the Responder responds to the IKE_SA_INIT request with a calculated "stateless cookie" - a value that can be 
-          re-calculated based on values in the IKE_SA_INIT request without storing Responder-side state. The Initiator is expected to 
-          repeat the IKE_SA_INIT request, this time including the stateless cookie.</t>
-        <t> Attackers that have multiple source IP addresses with return routability, such as in the case of bot-nets, can fill up a 
-          half-open SA table anyway. The cookie mechanism limits the amount of allocated state to the size of the bot-net, multiplied by 
-          the number of half-open SAs allowed per peer address, multiplied by the amount of state allocated for each half-open SA. With 
-          typical values this can easily reach hundreds of megabytes.</t>
-        <t> The mechanism described in <xref target="puzzles"/> adds a proof of work for the Initiator by calculating a pre-image for a 
-          partial hash value. This sets an upper bound, determined by the attacker's CPU, to the number of negotiations it can initiate 
-          in a unit of time.</t>
-      </section>    
-      <section anchor="mustshouldmay" title="Conventions Used in This Document">
-        <t>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
-          "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described
-          in <xref target="RFC2119"/>.</t>
-      </section>
-    </section>
-    <section anchor="analysis" title="The Vulnerability">
       <t> If we break down what a Responder has to do during an initial exchange, there are three stages:<list style="numbers">
         <t> When the IKE_SA_INIT request arrives, the Responder:<list style="symbols">
           <t> Generates or re-uses a Diffie-Hellman (D-H) private part.</t>
@@ -128,7 +115,8 @@
         address or prefix. The attacker can overcome this by using spoofed source addresses.</t>
       <t> The stateless cookie mechanism from Section 2.6 of <xref target="RFC7296"/> prevents an attack with spoofed source 
         addresses. This doesn't completely solve the issue, but it makes the limiting of half-open SAs by address or prefix work. 
-        Puzzles do the same thing only more of it. They make it harder for an attacker to reach the goal of getting a half-open SA. 
+        Puzzles, introduced in <xref target="puzzles"/>, do the same thing only more of it. 
+        They make it harder for an attacker to reach the goal of getting a half-open SA. 
         They don't have to be so hard that an attacker can't afford to solve a single puzzle; it's enough that they increase the 
         cost of a half-open SAs for the attacker so that it can create only a few.</t>
       <t> Reducing the amount of time an abandoned half-open SA is kept attacks the issue from the other side. It reduces the value 
@@ -145,8 +133,8 @@
       <t> On the other hand, sending an IKE_AUTH request is surprisingly cheap. It requires a proper IKE header with the correct IKE 
         SPIs, and it requires a single Encrypted payload. The content of the payload might as well be junk. The Responder has to 
         perform the relatively expensive key derivation, only to find that the MAC on the Encrypted payload on the IKE_AUTH request 
-        does not check. Depending on the Responder implementation, this can be repeated with the same half-open SA (if the Responder 
-        does not delete the half-open SA following an unsuccessful decryption - see discussion in <xref target="timelimit" />).</t>
+        does not check. Depending on the Responder implementation, this can be repeated with the same half-open SA.
+        Puzzles can make attacks of such sort more costly for an attacker. See <xref target="ikeauth" /> for details. </t>
       <t> Here too, the number of half-open SAs that the attacker can achieve is crucial, because each one allows the attacker to 
         waste some CPU time. So making it hard to make many half-open SAs is important.</t>
       <t> A strategy against DDoS has to rely on at least 4 components:<list style="numbers">
@@ -156,111 +144,200 @@
         <t> Increasing cost of half-open SA up to what is tolerable for legitimate clients.</t></list></t>
       <t>Puzzles have their place as part of #4.</t>
     </section>
-    <section anchor="puzzles" title="Puzzles">
-      <t> The puzzle introduced here extends the cookie mechanism from <xref target="RFC7296"/>. It is loosely based on the 
-        proof-of-work technique used in Bitcoins <xref target="bitcoins" />.</t>
-      <t> A puzzle is sent to the Initiator in two cases:<list style="symbols">
-        <t> The Responder is so overloaded that no half-open SAs may be created without solving a puzzle, or</t>
-        <!-- David Waltermire: The sentence containing the following text is difficult to parse. Consider rewording.
-                               [daw: I am at a loss for a shorter way to say this. I'd say leave it as it is.] -->
-        <t> The Responder is not too loaded, but the rate-limiting method described in <xref target="ratelimit" /> prevents half-open 
-          SAs from being created with this particular peer address or prefix without first solving a puzzle.</t></list></t>
-      <t> When the Responder decides to send the challenge notification in response to a IKE_SA_INIT request, the notification 
-        includes three fields:<list style="numbers">
-        <t> Cookie - this is calculated the same as in <xref target="RFC7296"/>, i.e. the process of generating the cookie is not 
-          specified.</t>
-        <t> Algorithm, this is the identifier of a Pseudo-Random Function (PRF) algorithm, one of those proposed by the Initiator in 
-          the SA payload.</t>
-        <t> Zero Bit Count (ZBC). This is a number between 8 and 255 (or a special value - 0, see <xref target="diflevelinit" />) that 
-          represents the length of the zero-bit run at the end of the output of the PRF function calculated over the cookie that the 
-          Initiator is to send. The values 1-8 are explicitly excluded, because they create a puzzle that is too easy to solve for it 
-          to make any difference in mitigating DDoS attacks. Since the mechanism is supposed to be stateless for the Responder, 
-          either the same ZBC is used for all Initiators, or the ZBC is somehow encoded in the cookie. If it is global then it means that 
-          this value is the same for all the Initiators who are receiving puzzles at any given point of time. The Responder, however, 
-          may change this value over time depending on its load.</t></list></t>
-      <t> Upon receiving this challenge, the Initiator attempts to calculate the PRF using different keys. 
-        When enough keys are found such that the resulting PRF output calculated using each of them has a 
-        sufficient number of trailing zero bits, that result is sent to the Responder.</t>
-      <t> The reason for using several keys in the results rather than just one key is to reduce the variance 
-        in the time it takes the initiator to solve the puzzle. We have chosen the number of keys to be four (4)
-        as a compromise between the conflicting goals of reducing variance and reducing the work the Responder 
-        needs to perform to verify the puzzle solution.</t>  
-      <t> When receiving a request with a solved puzzle, the Responder verifies two things:<list style="symbols">
-        <t> That the cookie part is indeed valid.</t>
-        <t> That the PRFs of the transmitted cookie calculated with the transmitted keys has a sufficient 
-          number of trailing zero bits.</t></list></t>
-      <t> Example 1: Suppose the calculated cookie is 739ae7492d8a810cf5e8dc0f9626c9dda773c5a3 (20 octets), 
-        the algorithm is PRF-HMAC-SHA256, and the required number of zero bits is 18. After successively 
-        trying a bunch of keys, the Initiator finds the following four 3-octet keys that work:</t>
-      <texttable anchor="tbl0" title="Three solutions for 18-bit puzzle">
-        <ttcol align="center">Key</ttcol>
-        <ttcol align="left">Last 32 Hex PRF Digits</ttcol>
-        <ttcol align="center"># 0-bits</ttcol>
-        <c>061840</c><c>e4f957b859d7fb1343b7b94a816c0000</c><c>18</c>
-        <c>073324</c><c>0d4233d6278c96e3369227a075800000</c><c>23</c>
-        <c>0c8a2a</c><c>952a35d39d5ba06709da43af40700000</c><c>20</c>
-        <c>0d94c8</c><c>5a0452b21571e401a3d00803679c0000</c><c>18</c>
-      </texttable>
-      <t> Example 2: Same cookie, but modify the required number of zero bits to 22. The first 4-octet keys 
-        that work to satisfy that requirement are 005d9e57, 010d8959, 0110778d, and 01187e37. Finding these 
-        requires 18,382,392 invocations of the PRF.</t>
-      <texttable anchor="tbl1" title="The time needed to solve a puzzle of various difficulty for the cookie = 739ae7492d8a810cf5e8dc0f9626c9dda773c5a3">
-        <ttcol align="center"># 0-bits</ttcol>
-        <ttcol align="right">Time to Find 4 keys (seconds)</ttcol>
-        <c> 8</c><c> 0.0025</c>
-        <c>10</c><c> 0.0078</c>
-        <c>12</c><c> 0.0530</c>
-        <c>14</c><c> 0.2521</c>
-        <c>16</c><c> 0.8504</c>
-        <c>17</c><c> 1.5938</c>
-        <c>18</c><c> 3.3842</c>
-        <c>19</c><c> 3.8592</c>
-        <c>20</c><c>10.8876</c>
-      </texttable>
-      <t> The figures above were obtained on a 2.4 GHz single core i5. Run times can be halved or quartered with multi-core code, but 
-        would be longer on mobile phone processors, even if those are multi-core as well. With these figures 18 bits is believed to 
-        be a reasonable choice for puzzle level difficulty for all Initiators, and 20 bits is acceptable for specific hosts/prefixes.</t>
+    <section anchor="defense" title="Defense Measures while IKE SA is being created">
+        <section anchor="timelimit" title="Retention Periods for Half-Open SAs">
+          <t> As a UDP-based protocol, IKEv2 has to deal with packet loss through retransmissions. Section 2.4 of <xref target="RFC7296"/> 
+            recommends "that messages be retransmitted at least a dozen times over a period of at least several minutes before giving up". 
+            Retransmission policies in practice wait at least one or two seconds before retransmitting for the first time.</t>
+          <t> Because of this, setting the timeout on a half-open SA too low will cause it to expire whenever even one IKE_AUTH request 
+            packet is lost. When not under attack, the half-open SA timeout SHOULD be set high enough that the Initiator will have 
+            enough time to send multiple retransmissions, minimizing the chance of transient network congestion causing IKE failure.</t>
+          <t> When the system is under attack, as measured by the amount of half-open SAs, it makes sense to reduce this lifetime. The 
+            Responder should still allow enough time for the round-trip, enough time for the Initiator to derive the D-H shared value, 
+            and enough time to derive the IKE SA keys and the create the IKE_AUTH request. Two seconds is probably as low a value as 
+            can realistically be used.</t>
+          <t> It could make sense to assign a shorter value to half-open SAs originating from IP addresses or prefixes that are 
+            considered suspect because of multiple concurrent half-open SAs.</t>
+        </section>
+        <section anchor="ratelimit" title="Rate Limiting">
+          <t> Even with DDoS, the attacker has only a limited amount of nodes participating in the attack. By limiting the amount of 
+            half-open SAs that are allowed to exist concurrently with each such node, the total amount of half-open SAs is capped, as 
+            is the total amount of key derivations that the Responder is forced to complete.</t>
+          <t> In IPv4 it makes sense to limit the number of half-open SAs based on IP address. Most IPv4 nodes are either directly 
+            attached to the Internet using a routable address or are hidden behind a NAT device with a single IPv4 external address. 
+            IPv6 networks are currently a rarity, so we can only speculate on what their wide deployment will be like, but the current 
+            thinking is that ISP customers will be assigned whole subnets, so we don't expect the kind of NAT deployment that is common 
+            in IPv4. For this reason, it makes sense to use a 64-bit prefix as the basis for rate limiting in IPv6.</t>
+          <t> The number of half-open SAs is easy to measure, but it is also worthwhile to measure the number of failed IKE_AUTH 
+            exchanges. If possible, both factors should be taken into account when deciding which IP address or prefix is considered 
+            suspicious.</t>
+          <t> There are two ways to rate-limit a peer address or prefix:<list style="numbers">
+            <t> Hard Limit - where the number of half-open SAs is capped, and any further IKE_SA_INIT requests are rejected.</t>
+            <t> Soft Limit - where if a set number of half-open SAs exist for a particular address or prefix, any IKE_SA_INIT request 
+              will require solving a puzzle.</t></list></t>
+          <t> The advantage of the hard limit method is that it provides a hard cap on the amount of half-open SAs that the attacker is 
+            able to create. The downside is that it allows the attacker to block IKE initiation from small parts of the Internet. 
+            For example, if an network service provider or some establishment offers Internet connectivity to its customers or 
+            employees through an IPv4 NAT device, a single malicious customer can create enough half-open SAs to fill the quota 
+            for the NAT device external IP address. Legitimate Initiators on the same network will not be able to initiate IKE.</t>
+          <t> The advantage of a soft limit is that legitimate clients can always connect. The disadvantage is that an adversary with 
+            sufficient CPU resources can still effectively DoS the Responder.</t>
+          <t> Regardless of the type of rate-limiting used, there is a huge advantage in blocking the DoS attack using rate-limiting 
+            for legitimate clients that are away from the attacking nodes. In such cases, adverse impacts caused by the attack 
+            or by the measures used to counteract the attack can be avoided.</t>
+        </section>
+        <section anchor="statelesscookie" title="The Stateless Cookie">  
+          <t> Section 2.6 of <xref target="RFC7296"/> offers a mechanism to mitigate DoS attack: the stateless cookie. When the server 
+            is under load, the Responder responds to the IKE_SA_INIT request with a calculated "stateless cookie" - a value that can be 
+            re-calculated based on values in the IKE_SA_INIT request without storing Responder-side state. The Initiator is expected to 
+            repeat the IKE_SA_INIT request, this time including the stateless cookie.</t>
+          <t> Attackers that have multiple source IP addresses with return routability, such as in the case of bot-nets, can fill up a 
+            half-open SA table anyway. The cookie mechanism limits the amount of allocated state to the size of the bot-net, multiplied by 
+            the number of half-open SAs allowed per peer address, multiplied by the amount of state allocated for each half-open SA. With 
+            typical values this can easily reach hundreds of megabytes.</t>
+        </section>    
+        <section anchor="puzzles" title="Puzzles">
+          <t> The puzzle introduced here extends the cookie mechanism from <xref target="RFC7296"/>. It is loosely based on the 
+            proof-of-work technique used in Bitcoins <xref target="bitcoins" />. This sets an upper bound, determined by the attacker's 
+            CPU, to the number of negotiations it can initiate in a unit of time.</t>
+          <t> A puzzle is sent to the Initiator in two cases:<list style="symbols">
+            <t> The Responder is so overloaded that no half-open SAs may be created without solving a puzzle, or</t>
+            <t> The Responder is not too loaded, but the rate-limiting method described in <xref target="ratelimit" /> prevents half-open 
+              SAs from being created with this particular peer address or prefix without first solving a puzzle.</t></list></t>
+          <t> When the Responder decides to send the challenge notification in response to a IKE_SA_INIT request, the notification 
+            includes three fields:<list style="numbers">
+            <t> Cookie - this is calculated the same as in <xref target="RFC7296"/>, i.e. the process of generating the cookie is not 
+              specified.</t>
+            <t> Algorithm, this is the identifier of a Pseudo-Random Function (PRF) algorithm, one of those proposed by the Initiator in 
+              the SA payload.</t>
+            <t> Zero Bit Count (ZBC). This is a number between 8 and 255 (or a special value - 0, see <xref target="diflevelinit" />) that 
+              represents the length of the zero-bit run at the end of the output of the PRF function calculated over the cookie that the 
+              Initiator is to send. The values 1-8 are explicitly excluded, because they create a puzzle that is too easy to solve for it 
+              to make any difference in mitigating DDoS attacks. Since the mechanism is supposed to be stateless for the Responder, 
+              either the same ZBC is used for all Initiators, or the ZBC is somehow encoded in the cookie. If it is global then it means that 
+              this value is the same for all the Initiators who are receiving puzzles at any given point of time. The Responder, however, 
+              may change this value over time depending on its load.</t></list></t>
+          <t> Upon receiving this challenge, the Initiator attempts to calculate the PRF using different keys. 
+            When enough keys are found such that the resulting PRF output calculated using each of them has a 
+            sufficient number of trailing zero bits, that result is sent to the Responder.</t>
+          <t> The reason for using several keys in the results rather than just one key is to reduce the variance 
+            in the time it takes the initiator to solve the puzzle. We have chosen the number of keys to be four (4)
+            as a compromise between the conflicting goals of reducing variance and reducing the work the Responder 
+            needs to perform to verify the puzzle solution.</t>  
+          <t> When receiving a request with a solved puzzle, the Responder verifies two things:<list style="symbols">
+            <t> That the cookie part is indeed valid.</t>
+            <t> That the PRFs of the transmitted cookie calculated with the transmitted keys has a sufficient 
+              number of trailing zero bits.</t></list></t>
+          <t> Example 1: Suppose the calculated cookie is 739ae7492d8a810cf5e8dc0f9626c9dda773c5a3 (20 octets), 
+            the algorithm is PRF-HMAC-SHA256, and the required number of zero bits is 18. After successively 
+            trying a bunch of keys, the Initiator finds the following four 3-octet keys that work:</t>
+          <texttable anchor="tbl0" title="Three solutions for 18-bit puzzle">
+            <ttcol align="center">Key</ttcol>
+            <ttcol align="left">Last 32 Hex PRF Digits</ttcol>
+            <ttcol align="center"># 0-bits</ttcol>
+            <c>061840</c><c>e4f957b859d7fb1343b7b94a816c0000</c><c>18</c>
+            <c>073324</c><c>0d4233d6278c96e3369227a075800000</c><c>23</c>
+            <c>0c8a2a</c><c>952a35d39d5ba06709da43af40700000</c><c>20</c>
+            <c>0d94c8</c><c>5a0452b21571e401a3d00803679c0000</c><c>18</c>
+          </texttable>
+          <t> Example 2: Same cookie, but modify the required number of zero bits to 22. The first 4-octet keys 
+            that work to satisfy that requirement are 005d9e57, 010d8959, 0110778d, and 01187e37. Finding these 
+            requires 18,382,392 invocations of the PRF.</t>
+          <texttable anchor="tbl1" title="The time needed to solve a puzzle of various difficulty for the cookie = 739ae7492d8a810cf5e8dc0f9626c9dda773c5a3">
+            <ttcol align="center"># 0-bits</ttcol>
+            <ttcol align="right">Time to Find 4 keys (seconds)</ttcol>
+            <c> 8</c><c> 0.0025</c>
+            <c>10</c><c> 0.0078</c>
+            <c>12</c><c> 0.0530</c>
+            <c>14</c><c> 0.2521</c>
+            <c>16</c><c> 0.8504</c>
+            <c>17</c><c> 1.5938</c>
+            <c>18</c><c> 3.3842</c>
+            <c>19</c><c> 3.8592</c>
+            <c>20</c><c>10.8876</c>
+          </texttable>
+          <t> The figures above were obtained on a 2.4 GHz single core i5. Run times can be halved or quartered with multi-core code, but 
+            would be longer on mobile phone processors, even if those are multi-core as well. With these figures 18 bits is believed to 
+            be a reasonable choice for puzzle level difficulty for all Initiators, and 20 bits is acceptable for specific hosts/prefixes.</t>
+          <t> Using puzzles mechanism in the IKE_SA_INIT exchange is described in <xref target="ikesainit"/>.</t>
+        </section>
+
+        <section anchor="resumption" title="Session Resumption">
+          <t>When the Responder is under attack, it MAY choose to prefer previously authenticated 
+          peers who present a Session Resumption ticket (see <xref target="RFC5723"/> for details). 
+          The Responder MAY require such Initiators to pass a return routability check by including the COOKIE 
+          notification in the IKE_SESSION_RESUME response message, as allowed by Section 4.3.2. of <xref target="RFC5723"/>.
+          Note that the Responder SHOULD cache tickets for a short time to reject reused tickets 
+          (Section 4.3.1), and therefore there should be no issue of half-open SAs resulting from 
+          replayed IKE_SESSION_RESUME messages. 
+          </t>
+        </section>
+
+        <section anchor="defenseikeauth" title="Keeping computed Shared Keys">
+            <t>Once the IKE_SA_INIT exchange is finished, the Responder is waiting for the first message of the 
+            IKE_AUTH exchange from the Initiator. At this point the Initiator is not yet authenticated and this 
+            fact allows a malicious peer to perform an attack, described in <xref target="analysis"/> - 
+            it can just send a garbage in the IKE_AUTH message thus forcing the Responder
+            to perform CPU costly operations to compute SK_* keys.</t>
+            <t> If the received IKE_AUTH message failed to decrypt correctly (or failed
+            to pass ICV check), then the Responder SHOULD still keep the computed
+            SK_* keys, so that if it happened to be an attack, then the malicious
+            Initiator cannot get advantage of repeating the attack multiple times on a single IKE SA.
+            The responder can also use puzzles in the IKE_AUTH exchange as decribed in <xref target="ikeauth"/>.</t>
+        </section>
     </section>
-    <section anchor="timelimit" title="Retention Periods for Half-Open SAs">
-      <t> As a UDP-based protocol, IKEv2 has to deal with packet loss through retransmissions. Section 2.4 of <xref target="RFC7296"/> 
-        recommends "that messages be retransmitted at least a dozen times over a period of at least several minutes before giving up". 
-        Retransmission policies in practice wait at least one or two seconds before retransmitting for the first time.</t>
-      <t> Because of this, setting the timeout on a half-open SA too low will cause it to expire whenever even one IKE_AUTH request 
-        packet is lost. When not under attack, the half-open SA timeout SHOULD be set high enough that the Initiator will have 
-        enough time to send multiple retransmissions, minimizing the chance of transient network congestion causing IKE failure.</t>
-      <t> When the system is under attack, as measured by the amount of half-open SAs, it makes sense to reduce this lifetime. The 
-        Responder should still allow enough time for the round-trip, enough time for the Initiator to derive the D-H shared value, 
-        and enough time to derive the IKE SA keys and the create the IKE_AUTH request. Two seconds is probably as low a value as 
-        can realistically be used.</t>
-      <t> It could make sense to assign a shorter value to half-open SAs originating from IP addresses or prefixes that are 
-        considered suspect because of multiple concurrent half-open SAs.</t>
-    </section>
-    <section anchor="ratelimit" title="Rate Limiting">
-      <t> Even with DDoS, the attacker has only a limited amount of nodes participating in the attack. By limiting the amount of 
-        half-open SAs that are allowed to exist concurrently with each such node, the total amount of half-open SAs is capped, as 
-        is the total amount of key derivations that the Responder is forced to complete.</t>
-      <t> In IPv4 it makes sense to limit the number of half-open SAs based on IP address. Most IPv4 nodes are either directly 
-        attached to the Internet using a routable address or are hidden behind a NAT device with a single IPv4 external address. 
-        IPv6 networks are currently a rarity, so we can only speculate on what their wide deployment will be like, but the current 
-        thinking is that ISP customers will be assigned whole subnets, so we don't expect the kind of NAT deployment that is common 
-        in IPv4. For this reason, it makes sense to use a 64-bit prefix as the basis for rate limiting in IPv6.</t>
-      <t> The number of half-open SAs is easy to measure, but it is also worthwhile to measure the number of failed IKE_AUTH 
-        exchanges. If possible, both factors should be taken into account when deciding which IP address or prefix is considered 
-        suspicious.</t>
-      <t> There are two ways to rate-limit a peer address or prefix:<list style="numbers">
-        <t> Hard Limit - where the number of half-open SAs is capped, and any further IKE_SA_INIT requests are rejected.</t>
-        <t> Soft Limit - where if a set number of half-open SAs exist for a particular address or prefix, any IKE_SA_INIT request 
-          will require solving a puzzle.</t></list></t>
-      <t> The advantage of the hard limit method is that it provides a hard cap on the amount of half-open SAs that the attacker is 
-        able to create. The downside is that it allows the attacker to block IKE initiation from small parts of the Internet. 
-        For example, if an network service provider or some establishment offers Internet connectivity to its customers or 
-        employees through an IPv4 NAT device, a single malicious customer can create enough half-open SAs to fill the quota 
-        for the NAT device external IP address. Legitimate Initiators on the same network will not be able to initiate IKE.</t>
-      <t> The advantage of a soft limit is that legitimate clients can always connect. The disadvantage is that an adversary with 
-        sufficient CPU resources can still effectively DoS the Responder.</t>
-      <t> Regardless of the type of rate-limiting used, there is a huge advantage in blocking the DoS attack using rate-limiting 
-        for legitimate clients that are away from the attacking nodes. In such cases, adverse impacts caused by the attack 
-        or by the measures used to counteract the attack can be avoided.</t>
+
+    <section anchor="dosprotikesa" title="Defense Measures after IKE SA is created">
+        <t>Once IKE SA is created there is usually not much traffic over it. In most cases this traffic 
+        consists of exchanges aimed to create additional Child SAs, rekey, or delete them 
+        and check the liveness of the peer. With a typical setup and typical Child SA lifetimes, 
+        there are typically no more than a few such exchanges, often less.
+        Some of these exchanges require relatively little resources (like liveness check),
+        while others may be resource consuming (like creating or rekeying Child SA with
+        D-H exchange).</t>
+
+        <t>Since any endpoint can initiate a new exchange, there is a possibility that a peer
+        would initiate too many exchanges that could exhaust host resources. 
+        For example, the peer can perform endless continuous Child SA rekeying or create 
+        overwhelming number of Child SAs with the same Traffic Selectors etc.
+        Such behavior may be caused by buggy implementation, misconfiguration or be intentional.
+        The latter becomes more of a real threat if the peer uses NULL Authentication, described
+        in <xref target="RFC7619"/>. In this case the peer remains anonymous, allowing 
+        it to escape any responsibility for its actions. 
+        </t>
+
+        <t>The following recommendations for defense against possible DoS attacks after
+        IKE SA is established are mostly intended for implementations that allow
+        unauthenticated IKE sessions; however, they may also be useful in other cases.
+        <list style="symbols">
+            <t> If the IKEv2 window size is greater than one, then the peer could initiate multiple
+            simultaneous exchanges that could increase host resource consumption.
+            Since currently there is no way in IKEv2 to decrease window size once it was increased 
+            (see Section 2.3 of <xref target="RFC7296"/>), the window size cannot be dynamically 
+            adjusted depending on the load. For that reason, it is NOT RECOMMENDED to ever increase 
+            the IKEv2 window size above its default value of one if the peer uses NULL Authentication.
+            </t>
+            <t> If the peer initiates requests to rekey IKE SA or Child SA too often, implementations
+            can respond to some of these requests with the TEMPORARY_FAILURE notification,
+            indicating that the request should be retried after some period of time.
+            </t>
+            <t> If the peer creates too many Child SA with the same or overlapping Traffic Selectors,
+            implementations can respond with the NO_ADDITIONAL_SAS notification.
+            </t>
+            <t> If the peer initiates too many exchanges of any kind, implementations can
+            introduce an artificial delay before responding to request messages. This delay
+            would decrease the rate the implementation need to process requests from 
+            any particular peer, making it possible to process requests from the others.
+            The delay should not be too long to avoid causing the IKE SA to be deleted on the other end
+            due to timeout. It is believed that a few seconds is enough. Note, that 
+            if the Responder receives retransmissions of the request message during 
+            the delay period, the retransmitted messages should be silently discarded.
+            </t>
+            <t> If these counter-measures are inefficient, implementations can
+            delete the IKE SA with an offending peer by sending Delete Payload.
+            </t>
+        </list>
+        </t>
     </section>
     <section anchor="plan" title="Plan for Defending a Responder">
       <t> This section outlines a plan for defending a Responder from a DDoS attack based on the techniques described earlier. 
@@ -307,16 +384,6 @@
         failures, the Responder MAY impose hard limits on those nodes.</t>
       <t> If it turns out that the attack is very widespread and the hard caps are not solving the issue, a puzzle MAY be imposed 
         on all Initiators. Note that this is the last step, and the Responder should avoid this if possible.</t>
-      <section anchor="resumption" title="Session Resumption">
-        <t>When the Responder is under attack, it MAY choose to prefer previously authenticated 
-        peers who present a Session Resumption ticket (see <xref target="RFC5723"/> for details). 
-        The Responder MAY require such Initiators to pass a return routability check by including the COOKIE 
-        notification in the IKE_SESSION_RESUME response message, as allowed by Section 4.3.2. of <xref target="RFC5723"/>.
-        Note that the Responder SHOULD cache tickets for a short time to reject reused tickets 
-        (Section 4.3.1), and therefore there should be no issue of half-open SAs resulting from 
-        replayed IKE_SESSION_RESUME messages. 
-        </t>
-      </section>
     </section>
 
     <section anchor="usingpuzzles" title="Using Puzzles in the Protocol">
@@ -473,9 +540,11 @@ Cookie = <VersionIDofSecret> | <AdditionalInfo> |
                 </t>
                 <t>If the received message contains a PUZZLE notification and doesn't contain 
                 a COOKIE notification, then this message is malformed because it requests to solve the puzzle, 
-                but doesn't provide enough information to do it. In this case the Initiator 
-                SHOULD resend IKE_SA_INIT request. If this situation repeats several times, 
-                then it means that something is wrong and the IKE SA cannot be established.
+                but doesn't provide enough information to do it. In this case the Initiator MUST ignore
+                the received message and continue to wait until either the valid one
+                is received or the retransmission timer fires. If it fails to receive the valid
+                message after several retransmissions of IKE_SA_INIT request, then
+                it means that something is wrong and the IKE SA cannot be established.
                 </t>
                 <t>If the Initiator supports puzzles and is ready to deal with them, then it tries 
                 to solve the given puzzle. After the puzzle is solved the Initiator restarts the request 
@@ -744,58 +813,6 @@ HDR, PS, SK {IDi, [CERT,] [CERTREQ,]
                 </t>
             </section>
         </section>
-    </section>
-    <section anchor="dosprotikesa" title="DoS Protection after IKE SA is created">
-        <t>Once IKE SA is created there is usually not much traffic over it. In most cases this traffic 
-        consists of exchanges aimed to create additional Child SAs, rekey, or delete them 
-        and check the liveness of the peer. With a typical setup and typical Child SA lifetimes, 
-        there are typically no more than a few such exchanges, often less.
-        Some of these exchanges require relatively little resources (like liveness check),
-        while others may be resource consuming (like creating or rekeying Child SA with
-        D-H exchange).</t>
-
-        <t>Since any endpoint can initiate a new exchange, there is a possibility that a peer
-        would initiate too many exchanges that could exhaust host resources. 
-        For example, the peer can perform endless continuous Child SA rekeying or create 
-        overwhelming number of Child SAs with the same Traffic Selectors etc.
-        Such behavior may be caused by buggy implementation, misconfiguration or be intentional.
-        The latter becomes more of a real threat if the peer uses NULL Authentication, described
-        in <xref target="RFC7619"/>. In this case the peer remains anonymous, allowing 
-        it to escape any responsibility for its actions. 
-        </t>
-
-        <t>The following recommendations for defense against possible DoS attacks after
-        IKE SA is established are mostly intended for implementations that allow
-        unauthenticated IKE sessions; however, they may also be useful in other cases.
-        <list style="symbols">
-            <t> If the IKEv2 window size is greater than one, then the peer could initiate multiple
-            simultaneous exchanges that could increase host resource consumption.
-            Since currently there is no way in IKEv2 to decrease window size once it was increased 
-            (see Section 2.3 of <xref target="RFC7296"/>), the window size cannot be dynamically 
-            adjusted depending on the load. For that reason, it is NOT RECOMMENDED to ever increase 
-            the IKEv2 window size above its default value of one if the peer uses NULL Authentication.
-            </t>
-            <t> If the peer initiates requests to rekey IKE SA or Child SA too often, implementations
-            can respond to some of these requests with the TEMPORARY_FAILURE notification,
-            indicating that the request should be retried after some period of time.
-            </t>
-            <t> If the peer creates too many Child SA with the same or overlapping Traffic Selectors,
-            implementations can respond with the NO_ADDITIONAL_SAS notification.
-            </t>
-            <t> If the peer initiates too many exchanges of any kind, implementations can
-            introduce an artificial delay before responding to request messages. This delay
-            would decrease the rate the implementation need to process requests from 
-            any particular peer, making it possible to process requests from the others.
-            The delay should not be too long to avoid causing the IKE SA to be deleted on the other end
-            due to timeout. It is believed that a few seconds is enough. Note, that 
-            if the Responder receives retransmissions of the request message during 
-            the delay period, the retransmitted messages should be silently discarded.
-            </t>
-            <t> If these counter-measures are inefficient, implementations can
-            delete the IKE SA with an offending peer by sending Delete Payload.
-            </t>
-        </list>
-        </t>
     </section>
     <section title="Payload Formats">
         <section anchor="puzzlentf" title="PUZZLE Notification">


### PR DESCRIPTION
1. Document structure changed (comments from Dave, Tommy, PaulW)
2. Text on retransmission of IKE_SA_INIT request clarified (comment from Tommy).
3. Clarification on keeping SK_\* if IKE_AUTH failed to decrypt
