### PR TITLE
Update key length for AES

### DIFF
--- a/draft-ietf-ipsecme-rfc4307bis
+++ b/draft-ietf-ipsecme-rfc4307bis
@@ -22,7 +22,7 @@
 <?rfc rfcedstyle="yes"?>
 
 <rfc ipr="trust200902"
-     docName="draft-ietf-ipsecme-rfc4307bis-10"
+     docName="draft-ietf-ipsecme-rfc4307bis-11"
      obsoletes="4307"
      updates="7296"
      category="std">
@@ -269,8 +269,8 @@
           <c>ENCR_3DES</c><c>MAY</c><c>No</c><c/>
           <c>ENCR_DES</c><c>MUST&nbsp;NOT</c><c>No</c><c/>
           <postamble>
-          [1] - This requirement level is for 128-bit keys. 256-bit
-	  keys are at SHOULD. 192-bit keys can safely be ignored.
+          [1] - This requirement level is for both 128-bit keys and 256-bit
+	  keys. 192-bit keys can safely be ignored and are considered MAY.
           [IoT] - This requirement is for interoperability with IoT.
             </postamble>
         </texttable>

--- a/draft-ietf-ipsecme-rfc4307bis
+++ b/draft-ietf-ipsecme-rfc4307bis
@@ -270,7 +270,8 @@
           <c>ENCR_DES</c><c>MUST&nbsp;NOT</c><c>No</c><c/>
           <postamble>
           [1] - This requirement level is for both 128-bit keys and 256-bit
-	  keys. 192-bit keys can safely be ignored and are considered MAY.
+	  keys, except for CCM. 192-bit keys can safely be ignored and are considered MAY for all modes, whereas 256-bit keys are
+	  a MAY for ENCR_AES_CCM_8 as well.
           [IoT] - This requirement is for interoperability with IoT.
             </postamble>
         </texttable>


### PR DESCRIPTION
Both 128- and 256-bit keys are a MUST. 

Did not change the requirements for AES-CCM: 128-bit is still MUST, 256-bit is still MAY and 192-bit is still not mentioned. The reasoning is that AES-CCM is a specific requirement of IoT and they have their own ideas about key lengths.
